### PR TITLE
Expose all translations

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -182,7 +182,7 @@ export class I18n extends Formatter {
   /**
    * Returns all translations
    */
-  getTranslations(): {[lang: string]: Record<string, string>} {
+  getTranslations(): { [lang: string]: Record<string, string> } {
     return this.#i18nManager.getTranslations()
   }
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -178,4 +178,11 @@ export class I18n extends Formatter {
   formatRawMessage(message: string, data?: Record<string, any>): string {
     return this.#i18nManager.getFormatter().format(message, this.locale, data)
   }
+
+  /**
+   * Returns all translations
+   */
+  getTranslations(): {[lang: string]: Record<string, string>} {
+    return this.#i18nManager.getTranslations()
+  }
 }

--- a/tests/i18n.spec.ts
+++ b/tests/i18n.spec.ts
@@ -186,7 +186,10 @@ test.group('I18n', () => {
     await i18nManager.loadTranslations()
     const i18n = new I18n('fr', emitter, i18nManager)
 
-    assert.deepEqual(i18n.getTranslations(), {en: {'messages.greeting': 'Hello, world!'}, fr: {'messages.greeting': 'Bonjour le monde !'}})
+    assert.deepEqual(i18n.getTranslations(), {
+      en: { 'messages.greeting': 'Hello, world!' },
+      fr: { 'messages.greeting': 'Bonjour le monde !' },
+    })
   })
 })
 

--- a/tests/i18n.spec.ts
+++ b/tests/i18n.spec.ts
@@ -168,6 +168,26 @@ test.group('I18n', () => {
     assert.isFalse(i18n.hasMessage('messages.greeting'))
     assert.isTrue(i18n.hasFallbackMessage('messages.greeting'))
   })
+
+  test('returns all available translations', async ({ fs, assert }) => {
+    await fs.createJson('resources/lang/en/messages.json', {
+      greeting: 'Hello, world!',
+    })
+    await fs.createJson('resources/lang/fr/messages.json', {
+      greeting: 'Bonjour le monde !',
+    })
+
+    const i18nManager = new I18nManager(emitter, {
+      defaultLocale: 'en',
+      formatter: () => new IcuFormatter(),
+      loaders: [() => new FsLoader({ location: join(fs.basePath, 'resources/lang') })],
+    })
+
+    await i18nManager.loadTranslations()
+    const i18n = new I18n('fr', emitter, i18nManager)
+
+    assert.deepEqual(i18n.getTranslations(), {en: {'messages.greeting': 'Hello, world!'}, fr: {'messages.greeting': 'Bonjour le monde !'}})
+  })
 })
 
 test.group('I18n | validator messages provider', () => {


### PR DESCRIPTION
## Proposed changes

Add a function on `I18n` class to get all the translations in all languages.

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/i18n/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This is an relatively trivial change but it's required to share my translations between Adonis and my Inertia app. I could iterate over available translations to build it, but it will be way uglier.