### PR TITLE
fix(configure): add entry to metaFiles

### DIFF
--- a/configure.ts
+++ b/configure.ts
@@ -42,5 +42,6 @@ export async function configure(command: Configure) {
    */
   await codemods.updateRcFile((rcFile) => {
     rcFile.addProvider('@adonisjs/i18n/i18n_provider')
+    rcFile.addMetaFile('resources/lang/**/*.json', false)
   })
 }

--- a/tests/configure.spec.ts
+++ b/tests/configure.spec.ts
@@ -20,7 +20,7 @@ test.group('Configure', (group) => {
     context.fs.basePath = fileURLToPath(BASE_URL)
   })
 
-  test('create config file and register provider', async ({ fs, assert }) => {
+  test('create config file, register provider and update meta files', async ({ fs, assert }) => {
     const ignitor = new IgnitorFactory()
       .withCoreProviders()
       .withCoreConfig()
@@ -51,6 +51,7 @@ test.group('Configure', (group) => {
     await assert.fileExists('app/middleware/detect_user_locale_middleware.ts')
     await assert.fileExists('adonisrc.ts')
     await assert.fileContains('adonisrc.ts', '@adonisjs/i18n/i18n_provider')
+    await assert.fileContains('adonisrc.ts', 'resources/lang/**/*.json')
     await assert.fileContains('config/i18n.ts', 'defineConfig')
     await assert.fileContains(
       'start/kernel.ts',


### PR DESCRIPTION
Hey there! 👋🏻 

This PR adds the `lang` directory to the `metaFiles` key in `adonisrc.ts` file.
It is needed to copy the files in a production build.

Closes https://github.com/adonisjs/i18n/issues/131